### PR TITLE
Add network overlay to hero honeycomb

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,16 @@
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
+      <div class="network-overlay" aria-hidden="true">
+        <svg viewBox="0 0 100 86.6" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <pattern id="hexGrid" width="10" height="8.66" patternUnits="userSpaceOnUse" patternTransform="scale(2)">
+              <polygon points="5,0 10,2.5 10,6.16 5,8.66 0,6.16 0,2.5" fill="none" stroke="currentColor" stroke-width="0.5" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#hexGrid)" />
+        </svg>
+      </div>
       <div class="container hero-content fade-in">
         <div class="text-area">
           <h1 data-key="hero_title"></h1>

--- a/styles.css
+++ b/styles.css
@@ -127,9 +127,24 @@ nav a:focus::after {
 
 /* Hero Section */
 .hero-section {
+  position: relative;
   padding-top: 100px; /* offset for fixed header */
   background-color: var(--color-primary);
   color: var(--color-light);
+}
+
+.network-overlay {
+  position: absolute;
+  inset: 0;
+  color: rgba(255, 255, 255, 0.4);
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.network-overlay svg {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .hero-content {


### PR DESCRIPTION
## Summary
- overlay hero section with a honeycomb network pattern
- style new network overlay for a tech look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888f9a65de4832c868e704a1216de0e